### PR TITLE
Adding possibility to write object definitions to separate files.

### DIFF
--- a/src/main/java/io/github/robwin/swagger2markup/Swagger2MarkupConverter.java
+++ b/src/main/java/io/github/robwin/swagger2markup/Swagger2MarkupConverter.java
@@ -46,6 +46,7 @@ public class Swagger2MarkupConverter {
     private final String examplesFolderPath;
     private final String schemasFolderPath;
     private final String descriptionsFolderPath;
+    private final boolean isSplitDescriptions;
     private static final String OVERVIEW_DOCUMENT = "overview";
     private static final String PATHS_DOCUMENT = "paths";
     private static final String DEFINITIONS_DOCUMENT = "definitions";
@@ -57,12 +58,13 @@ public class Swagger2MarkupConverter {
      * @param schemasFolderPath the folderPath where (XML, JSON)-Schema  files are stored
      * @param descriptionsFolderPath the folderPath where descriptions are stored
      */
-    Swagger2MarkupConverter(MarkupLanguage markupLanguage, Swagger swagger, String examplesFolderPath, String schemasFolderPath, String descriptionsFolderPath){
+    Swagger2MarkupConverter(MarkupLanguage markupLanguage, Swagger swagger, String examplesFolderPath, String schemasFolderPath, String descriptionsFolderPath, boolean isSplitDescriptions){
         this.markupLanguage = markupLanguage;
         this.swagger = swagger;
         this.examplesFolderPath = examplesFolderPath;
         this.schemasFolderPath = schemasFolderPath;
         this.descriptionsFolderPath = descriptionsFolderPath;
+        this.isSplitDescriptions = isSplitDescriptions;
     }
 
     /**
@@ -143,7 +145,7 @@ public class Swagger2MarkupConverter {
     private void buildDocuments(String directory) throws IOException {
         new OverviewDocument(swagger, markupLanguage).build().writeToFile(directory, OVERVIEW_DOCUMENT, StandardCharsets.UTF_8);
         new PathsDocument(swagger, markupLanguage, examplesFolderPath, descriptionsFolderPath).build().writeToFile(directory, PATHS_DOCUMENT, StandardCharsets.UTF_8);
-        new DefinitionsDocument(swagger, markupLanguage, schemasFolderPath, descriptionsFolderPath).build().writeToFile(directory, DEFINITIONS_DOCUMENT, StandardCharsets.UTF_8);
+        new DefinitionsDocument(swagger, markupLanguage, schemasFolderPath, descriptionsFolderPath, isSplitDescriptions, directory).build().writeToFile(directory, DEFINITIONS_DOCUMENT, StandardCharsets.UTF_8);
     }
 
     /**
@@ -154,7 +156,7 @@ public class Swagger2MarkupConverter {
     private String buildDocuments() throws IOException {
         return new OverviewDocument(swagger, markupLanguage).build().toString().concat(
                 new PathsDocument(swagger, markupLanguage, examplesFolderPath, schemasFolderPath).build().toString()
-                .concat(new DefinitionsDocument(swagger, markupLanguage, schemasFolderPath, schemasFolderPath).build().toString()));
+                .concat(new DefinitionsDocument(swagger, markupLanguage, schemasFolderPath, schemasFolderPath, false, null).build().toString()));
     }
 
 
@@ -163,6 +165,7 @@ public class Swagger2MarkupConverter {
         private String examplesFolderPath;
         private String schemasFolderPath;
         private String descriptionsFolderPath;
+        private boolean isSplitDescriptions;
         private MarkupLanguage markupLanguage = MarkupLanguage.ASCIIDOC;
 
         /**
@@ -187,7 +190,7 @@ public class Swagger2MarkupConverter {
         }
 
         public Swagger2MarkupConverter build(){
-            return new Swagger2MarkupConverter(markupLanguage, swagger, examplesFolderPath, schemasFolderPath, descriptionsFolderPath);
+            return new Swagger2MarkupConverter(markupLanguage, swagger, examplesFolderPath, schemasFolderPath, descriptionsFolderPath, isSplitDescriptions);
         }
 
         /**
@@ -209,6 +212,15 @@ public class Swagger2MarkupConverter {
          */
         public Builder withDescriptions(String descriptionsFolderPath){
             this.descriptionsFolderPath = descriptionsFolderPath;
+            return this;
+        }
+
+        /**
+         * In addition to definitions file, also create separate definition files for each entity. 
+         * @return the Swagger2MarkupConverter.Builder
+         */
+        public Builder withSplitDescriptions() {
+            this.isSplitDescriptions = true;
             return this;
         }
 

--- a/src/test/java/io/github/robwin/swagger2markup/Swagger2MarkupConverterTest.java
+++ b/src/test/java/io/github/robwin/swagger2markup/Swagger2MarkupConverterTest.java
@@ -24,6 +24,8 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.BDDAssertions.assertThat;
@@ -98,6 +100,26 @@ public class Swagger2MarkupConverterTest {
         //Then
         String[] directories = outputDirectory.list();
         assertThat(directories).hasSize(3).containsAll(asList("definitions.md", "overview.md", "paths.md"));
+    }
+
+    @Test
+    public void testSwagger2AsciiDocConversionWithSplitDescriptions() throws IOException {
+        //Given
+        File file = new File(Swagger2MarkupConverterTest.class.getResource("/json/swagger.json").getFile());
+        File outputDirectory = new File("build/docs/asciidoc/generated");
+        FileUtils.deleteQuietly(outputDirectory);
+
+        //When
+        Swagger2MarkupConverter.from(file.getAbsolutePath()).withSplitDescriptions().build()
+            .intoFolder(outputDirectory.getAbsolutePath());
+
+        //Then
+        String[] directories = outputDirectory.list();
+        assertThat(directories).hasSize(8).containsAll(
+            asList("definitions.adoc", "overview.adoc", "paths.adoc",
+                "user.adoc", "category.adoc", "pet.adoc", "tag.adoc", "order.adoc"));
+        assertThat(new String(Files.readAllBytes(Paths.get(outputDirectory + File.separator + "definitions.adoc"))))
+            .contains(new String(Files.readAllBytes(Paths.get(outputDirectory + File.separator + "user.adoc"))));
     }
 
     /*


### PR DESCRIPTION
I needed the ability to write the object definitions to separate files, with one file for each object.  This PR is a proposed implementation that doesn't break backward compatibility.

The only change in terms of usage is the addition of a `withSplitDescriptions()` method to `Swagger2MarkupConverter` to inform the converter that it should also generate separate files.  The rest of the changes are mainly internal refactoring to allow the use of multiple writers since we need to create a new one every time we encounter a new object definition.