### PR TITLE
Adding support for composed model definitions

### DIFF
--- a/src/test/resources/json/swagger.json
+++ b/src/test/resources/json/swagger.json
@@ -730,36 +730,47 @@
         }
     },
     "definitions": {
-        "User": {
+        "Identified": {
             "properties": {
                 "id": {
                     "type": "integer",
                     "format": "int64"
-                },
-                "username": {
-                    "type": "string"
-                },
-                "firstName": {
-                    "type": "string"
-                },
-                "lastName": {
-                    "type": "string"
-                },
-                "email": {
-                    "type": "string"
-                },
-                "password": {
-                    "type": "string"
-                },
-                "phone": {
-                    "type": "string"
-                },
-                "userStatus": {
-                    "type": "integer",
-                    "format": "int32",
-                    "description": "User Status"
                 }
             }
+        },
+        "User": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/Identified"
+                },
+                {
+                    "properties": {
+                        "username": {
+                            "type": "string"
+                        },
+                        "firstName": {
+                            "type": "string"
+                        },
+                        "lastName": {
+                            "type": "string"
+                        },
+                        "email": {
+                            "type": "string"
+                        },
+                        "password": {
+                            "type": "string"
+                        },
+                        "phone": {
+                            "type": "string"
+                        },
+                        "userStatus": {
+                            "type": "integer",
+                            "format": "int32",
+                            "description": "User Status"
+                        }
+                    }
+                }
+            ]
         },
         "Category": {
             "properties": {


### PR DESCRIPTION
Currently, if you have a composed definition (using the `allOf` device), no documentation is generated for that definition other than the header and description.  This is because the current `definition` code does not take into account `$ref`s or composition.

This adds support for both reference models and composed models.  The composition logic could likely be improved to provide better documentation for the composition (i.e. - where the definition came from, etc.), but for this improvement just flattens the composed model in the documentation.  I see this is a fine compromise given that's how the endpoint will behave, anyway.

Sorry/not-sorry for modifying the test suite's `swagger.json` - I wanted to make sure this didn't break any of the existing functionality.

Let me know what you think and I'm happy to address any concerns!